### PR TITLE
Npm publishable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Inspired by https://www.sitepoint.com/javascript-command-line-interface-cli-node
 
 ## Requirements
 
-* [Node.js](http://nodejs.org/)
+* [Node.js](http://nodejs.org/) version 6.10.0 or higher
 
 
 ## Installation
@@ -16,10 +16,15 @@ Inspired by https://www.sitepoint.com/javascript-command-line-interface-cli-node
 ## Usage
 
 	tetool --help
-    tetool --site ../exposure-inca-form/ --title 'Exposure Ontology' --source ../environmental-exposure-ontology/
-
+    tetool --site <targetSiteDir> --title <targetSiteTitle>
+    tetool --site <targetSiteDir> --source <ontologySourceDir>
+    tetool --site <targetSiteDir> --source <ontologySourceDir>@<branchName>
 
 ## Examples
+
+    tetool --site ../exposure-inca-form/ --title 'Exposure Ontology'
+    tetool --site ../exposure-inca-form/ --source ../environmental-exposure-ontology/
+    tetool --site ../planteome-inca-form/ --source ../plant-trait-ontology/@clean-dp
 
 ### Building the IncaForm site for `exposure-inca-form`
 
@@ -30,8 +35,36 @@ This example assumes that a single ontology repo will be used. For this example,
 - Use `tetool` to create a site directory:
 	tetool --site ./
 - This will create `docs/`, `docs/configurations/`, and `docs/index.html`
-- Use `tetool` to augment the site directory with generated configurations:
-	tetool --site ./
+- Use `tetool` to augment the site directory with configurations based upon ontology source directories
+	tetool --site ./ --source ../environmental-exposure-ontology/
+
+## Assumptions about the source directory structure
+
+In order to simplify the use of `tetool`, we make the assumption that a source ontology repository has a hierarchy resembling that in https://github.com/EnvironmentOntology/environmental-exposure-ontology:
+    source-repo/
+        src/
+            ontology/
+                a.csv
+                b.csv
+                ...
+            patterns/
+                a.yaml
+                b.yaml
+                ...
+
+In order to support Planteome, this was kludged to support structures like those in https://github.com/Planteome/plant-trait-ontology:
+    source-repo/
+        patterns/
+            a.yaml
+            a/
+                a.csv
+            b.yaml
+            b/
+                b.csv
+
+#### Problems with GO
+
+The current GO ontology https://github.com/geneontology/go-ontology does not follow either of these patterns, and therefore `tetool` will fail to find the appropriate patterns and XSV files. So `tetool` must be fixed to support GO.
 
 
 ## Developing `tetool`
@@ -40,7 +73,7 @@ This example assumes that a single ontology repo will be used. For this example,
 - cd to the repo directory
 - npm install # Install dependencies
 - Invent!
-- npm install -g # Install tetool globally, but from the working directory
+- npm install -g # Install tetool globally, from the local working directory
 
 
 ### Version History

--- a/README.md
+++ b/README.md
@@ -2,18 +2,22 @@
 
 Inspired by https://www.sitepoint.com/javascript-command-line-interface-cli-node-js
 
+
 ## Requirements
 
 * [Node.js](http://nodejs.org/)
+
 
 ## Installation
 
 `npm install -g tetool`
 
+
 ## Usage
 
 	tetool --help
-	tetool --target <site_dir>
+    tetool --site ../exposure-inca-form/ --title 'Exposure Ontology' --source ../environmental-exposure-ontology/
+
 
 ## Examples
 
@@ -26,6 +30,8 @@ This example assumes that a single ontology repo will be used. For this example,
 - Use `tetool` to create a site directory:
 	tetool --site ./
 - This will create `docs/`, `docs/configurations/`, and `docs/index.html`
+- Use `tetool` to augment the site directory with generated configurations:
+	tetool --site ./
 
 
 ## Developing `tetool`
@@ -36,6 +42,8 @@ This example assumes that a single ontology repo will be used. For this example,
 - Invent!
 - npm install -g # Install tetool globally, but from the working directory
 
-## License
 
-TBD
+### Version History
+
+0.0.1 - Initial version of tetool installed into NPM
+

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Manage inca-form configurations and sites",
   "main": "index.js",
   "scripts": {
+    "cleango": "rm -rf ../go-inca-form/docs/",
+    "go": "node index.js --site ../go-inca-form/ --title 'Gene Ontology' --source ../go-ontology/",
     "cleanexposure": "rm -rf ../exposure-inca-form/docs/",
     "exposure": "node index.js --site ../exposure-inca-form/ --title 'Exposure Ontology' --source ../environmental-exposure-ontology/",
     "cleanplanteome": "rm -rf ../planteome-inca-form/docs/",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,23 @@
 {
   "name": "tetool",
-  "version": "1.0.0",
-  "description": "Manage table-editor configurations and sites",
+  "version": "0.0.1",
+  "description": "Manage inca-form configurations and sites",
   "main": "index.js",
   "scripts": {
     "cleanexposure": "rm -rf ../exposure-inca-form/docs/",
     "exposure": "node index.js --site ../exposure-inca-form/ --title 'Exposure Ontology' --source ../environmental-exposure-ontology/",
     "cleanplanteome": "rm -rf ../planteome-inca-form/docs/",
-    "planteome": "node index.js --site ../planteome-inca-form/ --title 'Plant Ontology' --source ../plant-environment-ontology/ --source ../plant-trait-ontology/"
+    "planteome": "node index.js --site ../planteome-inca-form/ --title 'Planteome Plant Ontology' --source ../plant-environment-ontology/ --source ../plant-trait-ontology/@clean-dp",
+    "planteome0": "node index.js --site ../planteome-inca-form/ --title 'Planteome Plant Ontology'",
+    "planteome1": "node index.js --site ../planteome-inca-form/ --source ../plant-environment-ontology/",
+    "planteome2": "node index.js --site ../planteome-inca-form/ --source ../plant-trait-ontology/@clean-dp"
   },
   "keywords": [
     "tsv",
     "csv",
+    "xsv",
     "yaml",
-    "table-editor",
+    "inca-form",
     "CLI"
   ],
   "author": "Daniel Keith <dan@quantumclay.com>",


### PR DESCRIPTION
- tetool now accommodates the 'non-standard' planteome directory structure.
- Ensures that all references to docTemplates are relative to tetool, rather than current directory.
- Update README.
- Add GO tests, but GO ontology source directory is non-standard and won't work.
